### PR TITLE
improve management script

### DIFF
--- a/systemd/usr/lib/github-act-runner/github-act-runner.sh
+++ b/systemd/usr/lib/github-act-runner/github-act-runner.sh
@@ -564,7 +564,7 @@ function handle_log_command {
         case $1 in
             --help)
                 echo "usage:"
-                echo "	$(basename $0) <...> restart <runner-id> [<options>]"
+                echo "	$(basename $0) <...> log <runner-id> [<options>]"
                 echo ""
                 echo "options:"
                 echo "  --help    show this help text and do nothing."

--- a/systemd/usr/lib/github-act-runner/github-act-runner.sh
+++ b/systemd/usr/lib/github-act-runner/github-act-runner.sh
@@ -42,7 +42,8 @@ cur_err_trap=
 function add_to_err_trap {
     local cmd="$1;"
 
-    cur_err_trap="${cur_err_trap} $cmd"
+    # apply trap commands in reverse order, added last - executed first
+    cur_err_trap="$cmd ${cur_err_trap}"
     trap "${cur_err_trap}" ERR
 }
 
@@ -237,6 +238,9 @@ function handle_new_command {
         fi
         # echo "\$? = $?"
     )
+
+    # in case anything fails with setting up services below, we remove the registered runner from github
+    add_to_err_trap "(cd $runner_dir; $runner_bin remove --url $url --token ${opts[token]} > /dev/null)"
 
     # We add 3 service files. The idea is that one service file will be running the runner service itself.
     # Then there is a '.path' service file which watches the github-act-runner binary file for changes. When

--- a/systemd/usr/lib/github-act-runner/github-act-runner.sh
+++ b/systemd/usr/lib/github-act-runner/github-act-runner.sh
@@ -18,6 +18,7 @@ systemctl_cmd="systemctl"
 journalctl_cmd="journalctl --quiet"
 if $is_root; then
     echo "running as root"
+    journalctl_cmd="${journalctl_cmd} --unit"
     systemd_units_dir=/etc/systemd/system/
 else
     echo "running as user '$(id --user --name)'"


### PR DESCRIPTION
- remove `--id` options from `rm`, `stop`, `start` commands. The runner `id` is simply given as positional argument.
- add `restart` command
- add `log` command
- remove runner from github in case adding new runner fails on stages past the registration-on-github stage