### PR TITLE
Use files in .d directories for debian metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ This is a proof of concept runner prototype, which partially implements the azur
 ## usage from debian repo
 
 ### add debian repository
-`/etc/apt/sources.list` entry:
+`/etc/apt/sources.list.d/github-act-runner.list` file:
 ```
 deb http://gagis.hopto.org/repo/chrishx/deb all main
 ```
 
 ### import repository public key
 ```console
-curl -sS http://gagis.hopto.org/repo/chrishx/pubkey.gpg | sudo apt-key add -
+curl -sS http://gagis.hopto.org/repo/chrishx/pubkey.gpg | sudo tee -a /etc/apt/trusted.gpg.d/chrishx-github-act-runner.asc
 ```
 
 ### install the runner


### PR DESCRIPTION
The new form `.d` directories are a lot easier for admins.

https://manpages.ubuntu.com/manpages/xenial/man5/sources.list.5.html

## SOURCES.LIST.D
> The /etc/apt/sources.list.d directory provides a way to add sources.list entries in
       separate files. 

http://manpages.ubuntu.com/manpages/bionic/man8/apt-key.8.html
## FILES
>       /etc/apt/trusted.gpg.d/
           File fragments for the trusted keys, additional keyrings can be stored here (by other
           packages or the administrator). Configuration Item Dir::Etc::TrustedParts.
