### PR TITLE
Use a waitgroup instead of replacing a context

### DIFF
--- a/main.go
+++ b/main.go
@@ -1782,6 +1782,7 @@ func runJob(vssConnection *protocol.VssConnection, run *RunRunner, cancel contex
 				defer func() {
 					joblock.Unlock()
 				}()
+				<-jobctx.Done()
 				close(joblch)
 			}()
 			var err error

--- a/main.go
+++ b/main.go
@@ -1800,6 +1800,7 @@ func runJob(vssConnection *protocol.VssConnection, run *RunRunner, cancel contex
 				}
 				err = rc.Executor()(common.WithJobErrorContainer(common.WithLogger(jobExecCtx, logger)))
 			case <-jobExecCtx.Done():
+				finishWait()
 			}
 
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -616,11 +616,11 @@ func containsEphemeralConfiguration() bool {
 func (run *RunRunner) Run() int {
 	// This is used to wait for possible multiple jobs, they would execute sequentially and we need to wait for all
 	var jobCompletedWG sync.WaitGroup
-	allJobsDone := func() chan struct{} {
-		ch := make(chan struct{})
+	allJobsDone := func() chan interface{} {
+		ch := make(chan interface{})
 		go func() {
 			jobCompletedWG.Wait()
-			ch <- jobCompletedWG
+			ch <- nil
 		}()
 		return ch
 	}

--- a/main.go
+++ b/main.go
@@ -1764,7 +1764,7 @@ func runJob(vssConnection *protocol.VssConnection, run *RunRunner, cancel contex
 			logger.Log(logrus.InfoLevel, "Runner Version: "+version)
 
 			// Wait for possible concurrent running job and serialize, this only happens for multi repository runners
-			waitContext, finishWait := context.WithCancel(jobExecCtx)
+			waitContext, finishWait := context.WithCancel(jobctx)
 			go func() {
 				for {
 					select {

--- a/main.go
+++ b/main.go
@@ -1782,8 +1782,8 @@ func runJob(vssConnection *protocol.VssConnection, run *RunRunner, cancel contex
 				defer func() {
 					joblock.Unlock()
 				}()
-				<-jobctx.Done()
 				close(joblch)
+				<-jobctx.Done()
 			}()
 			var err error
 			select {
@@ -1800,7 +1800,6 @@ func runJob(vssConnection *protocol.VssConnection, run *RunRunner, cancel contex
 				}
 				err = rc.Executor()(common.WithJobErrorContainer(common.WithLogger(jobExecCtx, logger)))
 			case <-jobExecCtx.Done():
-				finishWait()
 			}
 
 			if err != nil {


### PR DESCRIPTION
Should fix another race condition
- stopping a multi configuration runner, if they execute multiple jobs sequentially
- cancelling individual jobs and not the last one
- allow wait loop to be cancelled

Resolves #66