### PR TITLE
fix: all steps have duration of 0, since 0.3.0

### DIFF
--- a/actionsrunner/worker_context.go
+++ b/actionsrunner/worker_context.go
@@ -113,5 +113,6 @@ func (wc *DefaultWorkerContext) Init() {
 	jobEntry := wc.Logger().Append(protocol.CreateTimelineEntry("", wc.Message().JobName, wc.Message().JobDisplayName))
 	jobEntry.ID = wc.Message().JobID
 	jobEntry.Type = "Job"
+	jobEntry.Order = 0
 	jobEntry.Start()
 }

--- a/protocol/job_logger.go
+++ b/protocol/job_logger.go
@@ -246,13 +246,17 @@ func (logger *JobLogger) MoveNext() *TimelineRecord {
 	if logger.CurrentBuffer.Len() > 0 {
 		if logid, err := logger.Connection.UploadLogFile(logger.JobRequest.Timeline.ID, logger.JobRequest, logger.CurrentBuffer.String()); err == nil {
 			logger.Current().Log = &TaskLogReference{ID: logid}
-			_ = logger.Update()
 		}
 	}
 	logger.CurrentRecord++
 	logger.CurrentLine = 1
 	logger.CurrentBuffer.Reset()
-	return logger.Current()
+	if c := logger.Current(); c != nil {
+		c.Start()
+		_ = logger.Update()
+		return c
+	}
+	return nil
 }
 
 func (logger *JobLogger) Finish() {


### PR DESCRIPTION
If GitHub doesn't see an inprogress step timeline event duration is always zero