### PR TITLE
Allow direct runner interaction in deb package

### DIFF
--- a/systemd/usr/lib/github-act-runner/github-act-runner.sh
+++ b/systemd/usr/lib/github-act-runner/github-act-runner.sh
@@ -645,7 +645,7 @@ function handle_run_command {
     exit "$exitcode"
 }
 
-function handle_run_command {
+function handle_worker_command {
     "${runner_bin}" worker "$@"
 }
 


### PR DESCRIPTION
Previously the raw runner commands were not exposed to the deb package