### PR TITLE
Use git clone if using RunnerJobRequest

### DIFF
--- a/actionsdotnetactcompat/act_worker.go
+++ b/actionsdotnetactcompat/act_worker.go
@@ -354,6 +354,9 @@ func ExecWorker(rqt *protocol.AgentJobRequestMessage, wc actionsrunner.WorkerCon
 			return nil
 		}
 	}
+	if strings.EqualFold(rqt.MessageType, "RunnerJobRequest") {
+		runnerConfig.DownloadAction = nil
+	}
 	rc := &runner.RunContext{
 		Name:   uuid.New().String(),
 		Config: runnerConfig,


### PR DESCRIPTION
Use the previous git clone backend if we get a "RunnerJobRequest" Message from broker service.

Implement Launch service support, if everything has been proven to work. 

Via #96