### PR TITLE
use gzip instead of xst for deb compression

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -29,3 +29,8 @@ override_dh_auto_install:
 .PHONY: override_dh_strip
 override_dh_strip:
 	@echo "skip stripping"
+
+# override build rule to use old gzip compression instead of new zst compression
+# because some not very old Debian releases do not support zst compression
+override_dh_builddeb:
+	dh_builddeb -- -Zgzip


### PR DESCRIPTION
I'm currently using Armbian based on Debian Buster on my Odroid xu4 runners and it does not support newly introduced in latest Debain `xst` compression of deb packages. 
This PR makes deb packages to use old `gzip` compression for wider compatibility.