### PR TITLE
Fix actions-runner-worker.ps1

### DIFF
--- a/compat/actions-runner-worker.ps1
+++ b/compat/actions-runner-worker.ps1
@@ -42,7 +42,7 @@ echo "Wait for exit"
 Wait-Process -InputObject $proc
 $exitCode = $proc.ExitCode
 # https://github.com/actions/runner/blob/af6ed41bcb47019cce2a7035bad76c97ac97b92a/src/Runner.Common/Util/TaskResultUtil.cs#L13-L14
-if(($exitCode -ge 100) -or ($exitCode -le 105)) {
+if(($exitCode -ge 100) -and ($exitCode -le 105)) {
     $conclusion = 0
 } else {
     $conclusion = 1


### PR DESCRIPTION
Previously it never had used exit code 1 even if dotnet crashed