### PR TITLE
jitconfig: add missing GitHubUrl to DotnetAgent

### DIFF
--- a/runnerconfiguration/compat/actions_runner_compat.go
+++ b/runnerconfiguration/compat/actions_runner_compat.go
@@ -34,7 +34,7 @@ type DotnetAgent struct {
 	PoolName      string `json:"PoolName,omitempty"`
 	ServerUrl     string `json:"ServerUrl"`
 	WorkFolder    string `json:"WorkFolder"`
-	GitHubUrl 	  string `json:"GitHubUrl"`
+	GitHubUrl     string `json:"GitHubUrl"`
 }
 
 type DotnetCredentials struct {


### PR DESCRIPTION
The jittoken couldn't be used to remove the actions/runner. github-act-runner would had asked for the url, but better follow the actions service.

Originally reported here: <https://github.com/actions/runner/issues/2920>