### PR TITLE
python wrapper remove bad encoding from console

### DIFF
--- a/compat/actions-runner-worker.py
+++ b/compat/actions-runner-worker.py
@@ -20,7 +20,6 @@ def redirectio():
         messageLength = int.from_bytes(os.read(stdin, 4), "big", signed=False)
         message = os.read(stdin, messageLength)
         encoded = codecs.decode(message, "utf-8").encode("utf_16")[2:]        
-        print(encoded)
         os.write(rdw, len(encoded).to_bytes(4, sys.byteorder, signed=False))
         os.write(rdw, encoded)
 


### PR DESCRIPTION
This print just added noice to the worker crashed message and wasn't readable either way.