### PR TITLE
add run command env options to svc

### DIFF
--- a/main.go
+++ b/main.go
@@ -195,7 +195,7 @@ func (svc *RunRunnerSvc) Start(s service.Service) error {
 		JITConfig: os.Getenv("ACTIONS_RUNNER_INPUT_JITCONFIG"),
 		Terminal:  true,
 	}
-	if workerArgs, ok := os.LookupEnv("ACTIONS_RUNNER_INPUT_WORKER_RUNNER"); ok {
+	if workerArgs, ok := os.LookupEnv("ACTIONS_RUNNER_INPUT_WORKER_ARGS"); ok {
 		runner.WorkerArgs = strings.Split(workerArgs, ",")
 	}
 	if once, ok := common.LookupEnvBool("ACTIONS_RUNNER_INPUT_ONCE"); ok {


### PR DESCRIPTION
* also remove the input env keys

I have now a setup where I need to set the ACTIONS_RUNNER_INPUT_WORKER_ARGS in a service.

My conclusion is that this fits best into the `--env-file` where you can now put this key, instead of putting it in the service command.