### PR TITLE
Fix configureing the runner due to User-Agent dependent Response

### DIFF
--- a/protocol/connection.go
+++ b/protocol/connection.go
@@ -242,7 +242,7 @@ func (vssConnection *VssConnection) requestWithContextNoAuth(
 			header.Set(acceptHeader, "application/json")
 		}
 	}
-	header["User-Agent"] = []string{"GitHubActionsRunner-Unknown/0"}
+	header["User-Agent"] = []string{"github-act-runner/v0.11.0"}
 	if apiversion != "" {
 		// vssservice does only accept contenttype in a single line
 		if len(header[contentTypeHeader]) > 0 {


### PR DESCRIPTION
* Without User Agent we get now url https://broker.actions.githubusercontent.com/rest
* The new url is not a vss server and v2 flow is not enabled

Closes #219 