### PR TITLE
Fix respect Server Decision to use v2 broker flow

### DIFF
--- a/protocol/connection.go
+++ b/protocol/connection.go
@@ -357,16 +357,32 @@ func (vssConnection *VssConnection) CreateSessionExt(ctx context.Context, server
 
 	con := &AgentMessageConnection{VssConnection: vssConnection, TaskAgentSession: session}
 	con.Status = statusOnline
+	con.ServerV2URL = serverV2URL
 	return con, nil
 }
 
 func (vssConnection *VssConnection) CreateSession(ctx context.Context) (*AgentMessageConnection, error) {
-	return vssConnection.CreateSessionExt(ctx, vssConnection.TaskAgent.ServerV2URL)
+	useV2Flow, hasUseV2Flow := vssConnection.TaskAgent.Properties.LookupBool("UseV2Flow")
+	serverV2URL, hasServerV2URL := vssConnection.TaskAgent.Properties.LookupString("ServerUrlV2")
+	if !useV2Flow || !hasUseV2Flow || !hasServerV2URL {
+		serverV2URL = ""
+	} else {
+		serverV2URL = strings.TrimSuffix(serverV2URL, "/")
+	}
+	return vssConnection.CreateSessionExt(ctx, serverV2URL)
 }
 
 func (vssConnection *VssConnection) LoadSession(ctx context.Context, session *TaskAgentSession) (*AgentMessageConnection, error) {
 	con := &AgentMessageConnection{VssConnection: vssConnection, TaskAgentSession: session}
 	con.Status = statusOnline
+	useV2Flow, hasUseV2Flow := vssConnection.TaskAgent.Properties.LookupBool("UseV2Flow")
+	serverV2URL, hasServerV2URL := vssConnection.TaskAgent.Properties.LookupString("ServerUrlV2")
+	if !useV2Flow || !hasUseV2Flow || !hasServerV2URL {
+		serverV2URL = ""
+	} else {
+		serverV2URL = strings.TrimSuffix(serverV2URL, "/")
+	}
+	con.ServerV2URL = serverV2URL
 	return con, nil
 }
 

--- a/runnerconfiguration/add.go
+++ b/runnerconfiguration/add.go
@@ -81,7 +81,7 @@ func (config *ConfigureRunner) Configure(
 	}
 	if res.UseV2FLow {
 		vssConnection = &protocol.VssConnection{
-			AuthHeader: "RemoteAuth " + config.Token,
+			AuthHeader: "Bearer " + res.Token,
 			Trace:      config.Trace,
 			Client:     c,
 		}
@@ -309,7 +309,6 @@ func registerOrReplaceRunnerV2(taskAgent *protocol.TaskAgent, config *ConfigureR
 	taskAgent.Name = runnerResp.Name
 	taskAgent.Authorization.AuthorizationURL = runnerResp.Authorization.AuthorizationURL
 	taskAgent.Authorization.ClientID = runnerResp.Authorization.ClientId
-	taskAgent.ServerV2URL = runnerResp.Authorization.ServerURL
 	return nil
 }
 


### PR DESCRIPTION
* Store Agent Properties in our json and map it to DotnetAgent
* Decide to use Brokerlistener based on the available property
* Use Bearer token for runner admin flow, which is still disabled for us