### PR TITLE
Upload step summary (github.com only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ go run . run
 - ~~Running steps after cancellation~~ Is now working in 0.6.0
 - ~~steps.timeout-minutes not implemented~~ Is now working in 0.6.0
 - ~~Service Container are not implemented~~ Is now working in 0.7.0
-- Step Summaries are not implemented (only file command is provided)
+- ~~Step Summaries are not implemented (only file command is provided)~~ Is now part of 0.13.1
 - Annotations are not implemented
 - Problem Matcher are not implemented
 - Expressions in `with` and `env` (also applies to workflow and job env blocks) keys / directly assign to a mapping expression are not implemented

--- a/actionsdotnetactcompat/act_worker.go
+++ b/actionsdotnetactcompat/act_worker.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/actions-oss/act-cli/pkg/common"
@@ -44,6 +45,7 @@ const (
 )
 
 type ghaFormatter struct {
+	m             sync.Mutex
 	rqt           *protocol.AgentJobRequestMessage
 	rc            *runner.RunContext
 	logger        *logger.JobLogger
@@ -95,6 +97,8 @@ func (f *ghaFormatter) EvaluateStep(ctx context.Context, rec *protocol.TimelineR
 }
 
 func (f *ghaFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
 	b := &bytes.Buffer{}
 	var stepID string
 	stage, hasStage := entry.Data["stage"]
@@ -216,6 +220,10 @@ func (f *ghaFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		msg = arg
 	case "ignored":
 		msg = raw
+	case "summary":
+		content, _ := entry.Data["content"].(string)
+		// Upload Async
+		go f.logger.UploadStepSummary(f.logger.Current(), content)
 	}
 	msg = f.linefeedregex.ReplaceAllString(prefix+strings.Trim(msg, "\r\n"), "\n"+prefix)
 

--- a/actionsdotnetactcompat/act_worker.go
+++ b/actionsdotnetactcompat/act_worker.go
@@ -222,8 +222,7 @@ func (f *ghaFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		msg = raw
 	case "summary":
 		content, _ := entry.Data["content"].(string)
-		// Upload Async
-		go f.logger.UploadStepSummary(f.logger.Current(), content)
+		f.logger.UploadStepSummary(f.logger.Current(), content)
 	}
 	msg = f.linefeedregex.ReplaceAllString(prefix+strings.Trim(msg, "\r\n"), "\n"+prefix)
 

--- a/protocol/logger/job_logger.go
+++ b/protocol/logger/job_logger.go
@@ -445,6 +445,18 @@ func (logger *JobLogger) MoveNextExt(startNextRecord bool) *protocol.TimelineRec
 	return nil
 }
 
+func (logger *JobLogger) UploadStepSummary(cur *protocol.TimelineRecord, summary string) {
+	if logger.ResultsConnection != nil && cur != nil && summary != "" {
+		rs := &results.ResultsService{
+			Connection: logger.ResultsConnection,
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), resultsUploadTimeout)
+		defer cancel()
+		_ = rs.UploadResultsStepSummaryAsync(ctx, logger.JobRequest.Plan.PlanID, logger.JobRequest.JobID, cur.ID,
+			strings.NewReader(summary), int64(len(summary))) // Ignore upload error for async operation
+	}
+}
+
 func (logger *JobLogger) uploadBlock(cur *protocol.TimelineRecord, finalBlock bool) {
 	if !logger.IsResults && finalBlock && logger.CurrentBuffer.Len() > 0 {
 		logid, err := logger.Connection.UploadLogFile(

--- a/protocol/results/contracts.go
+++ b/protocol/results/contracts.go
@@ -14,7 +14,7 @@ type GetSignedStepSummaryURLRequest struct {
 
 type GetSignedStepSummaryURLResponse struct {
 	SummaryURL      string `json:"summary_url,omitempty"`
-	SoftSizeLimit   int64  `json:"soft_size_limit,omitempty"`
+	SoftSizeLimit   string `json:"soft_size_limit,omitempty"`
 	BlobStorageType string `json:"blob_storage_type,omitempty"`
 }
 

--- a/protocol/results/service.go
+++ b/protocol/results/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/ChristopherHX/github-act-runner/protocol"
@@ -106,7 +107,8 @@ func (rs *ResultsService) UploadResultsStepSummaryAsync(
 	if uploadURLResponse.SummaryURL == "" {
 		return fmt.Errorf("failed to get step log upload url")
 	}
-	if fileSize > uploadURLResponse.SoftSizeLimit {
+	softSizeLimit, _ := strconv.ParseInt(uploadURLResponse.SoftSizeLimit, 10, 64)
+	if fileSize > softSizeLimit && softSizeLimit > 0 {
 		return fmt.Errorf(
 			"file size is larger than the upload url allows, file size: %v, upload url size: %v",
 			fileSize,


### PR DESCRIPTION
- errata `SoftSizeLimit int64` changed to `SoftSizeLimit string`
- synced `func (f *ghaFormatter) Format(entry *logrus.Entry) ([]byte, error) {` with mutex

```yaml
    - name: Upload Step Summary
      run: |
        tee -a "$GITHUB_STEP_SUMMARY" << 'EOF'
        # Summary from gh-act-runner
        This generates a step summary via custom code
        - line 1
        - line 2
        EOF
```

<img width="1516" height="218" alt="image" src="https://github.com/user-attachments/assets/5dec678b-c5bc-42ed-9174-27b05a3f38a5" />
